### PR TITLE
feat: Add embedded struct support for DynamORM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,12 +98,28 @@ The codebase includes specific optimizations for Lambda in `lambda.go`:
    - `dynamorm:"pk"` - Partition key
    - `dynamorm:"sk"` - Sort key
    - `dynamorm:"created_at"` - Custom attribute name
+   - `dynamorm:"index:gsi1,pk"` - GSI partition key
+   - `dynamorm:"index:gsi1,sk"` - GSI sort key
 
-2. **Error Handling**: Custom error types in `/pkg/errors/` with retry strategies
+2. **Embedded Structs**: DynamORM supports embedded structs for code reuse:
+   ```go
+   type BaseModel struct {
+       PK        string    `dynamorm:"pk"`
+       SK        string    `dynamorm:"sk"`
+       UpdatedAt time.Time `dynamorm:"updated_at"`
+   }
+   
+   type Customer struct {
+       BaseModel  // Embedded fields are recognized
+       Name string
+   }
+   ```
 
-3. **Performance**: Focus on reducing allocations and reusing resources
+3. **Error Handling**: Custom error types in `/pkg/errors/` with retry strategies
 
-4. **Multi-Account**: Built-in support via `WithMultiAccount()` option
+4. **Performance**: Focus on reducing allocations and reusing resources
+
+5. **Multi-Account**: Built-in support via `WithMultiAccount()` option
 
 ## Development Workflow
 

--- a/examples/embedded_structs_example.go
+++ b/examples/embedded_structs_example.go
@@ -1,0 +1,215 @@
+// Package examples demonstrates DynamORM's embedded struct support
+package examples
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/pay-theory/dynamorm"
+	"github.com/pay-theory/dynamorm/pkg/session"
+)
+
+// BaseModel represents common fields for a single-table design pattern
+// This struct can be embedded in other models to share common fields
+type BaseModel struct {
+	// Primary composite keys
+	PK string `dynamorm:"pk"`
+	SK string `dynamorm:"sk"`
+
+	// Global Secondary Indexes for access patterns
+	GSI1PK string `dynamorm:"index:gsi1,pk"`
+	GSI1SK string `dynamorm:"index:gsi1,sk"`
+	GSI2PK string `dynamorm:"index:gsi2,pk"`
+	GSI2SK string `dynamorm:"index:gsi2,sk"`
+
+	// Common metadata
+	Type      string    `dynamorm:"attr:type"`
+	TenantID  string    `dynamorm:"attr:tenant_id"`
+	CreatedAt time.Time `dynamorm:"created_at"`
+	UpdatedAt time.Time `dynamorm:"updated_at"`
+	Version   int       `dynamorm:"version"`
+}
+
+// EmbeddedCustomer demonstrates embedding BaseModel for a customer entity
+type EmbeddedCustomer struct {
+	BaseModel // Embedded struct - all fields are inherited
+
+	// Customer-specific fields
+	ID    string `dynamorm:"attr:id"`
+	Email string `dynamorm:"attr:email"`
+	Name  string `dynamorm:"attr:name"`
+	Phone string `dynamorm:"attr:phone"`
+}
+
+// TableName returns the DynamoDB table name
+func (c *EmbeddedCustomer) TableName() string {
+	return "my-application"
+}
+
+// Product demonstrates the same pattern for a different entity type
+type EmbeddedProduct struct {
+	BaseModel // Same embedded struct
+
+	// Product-specific fields
+	ID          string  `dynamorm:"attr:id"`
+	Name        string  `dynamorm:"attr:name"`
+	Description string  `dynamorm:"attr:description"`
+	Price       float64 `dynamorm:"attr:price"`
+	Stock       int     `dynamorm:"attr:stock"`
+	CategoryID  string  `dynamorm:"attr:category_id"`
+}
+
+// TableName returns the DynamoDB table name
+func (p *EmbeddedProduct) TableName() string {
+	return "my-application"
+}
+
+// Order shows how to use embedded structs with relationships
+type EmbeddedOrder struct {
+	BaseModel // Embedded struct
+
+	// Order-specific fields
+	ID         string    `dynamorm:"attr:id"`
+	CustomerID string    `dynamorm:"attr:customer_id"`
+	Total      float64   `dynamorm:"attr:total"`
+	Status     string    `dynamorm:"attr:status"`
+	OrderedAt  time.Time `dynamorm:"attr:ordered_at"`
+}
+
+// TableName returns the DynamoDB table name
+func (o *EmbeddedOrder) TableName() string {
+	return "my-application"
+}
+
+// ExampleEmbeddedStructs demonstrates how to use embedded structs with DynamORM
+func ExampleEmbeddedStructs() {
+	// Initialize DynamORM
+	config := session.Config{
+		Region: "us-east-1",
+	}
+
+	db, err := dynamorm.New(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a customer with the embedded BaseModel fields
+	customer := &EmbeddedCustomer{
+		BaseModel: BaseModel{
+			PK:       "CUSTOMER#cus_123",
+			SK:       "METADATA",
+			GSI1PK:   "TENANT#tenant_456",
+			GSI1SK:   "CUSTOMER#cus_123",
+			GSI2PK:   "EMAIL#john@example.com",
+			GSI2SK:   "CUSTOMER#cus_123",
+			Type:     "customer",
+			TenantID: "tenant_456",
+			// CreatedAt and UpdatedAt are set automatically
+		},
+		ID:    "cus_123",
+		Email: "john@example.com",
+		Name:  "John Doe",
+		Phone: "+1234567890",
+	}
+
+	// Create the customer
+	if err := db.Model(customer).Create(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Customer created at: %v\n", customer.CreatedAt)
+
+	// Query customers by tenant using GSI1
+	var customers []EmbeddedCustomer
+	err = db.Model(&EmbeddedCustomer{}).
+		Index("gsi1").
+		Where("GSI1PK", "=", "TENANT#tenant_456").
+		Where("GSI1SK", "BEGINS_WITH", "CUSTOMER#").
+		All(&customers)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Found %d customers for tenant\n", len(customers))
+
+	// Create a product using the same base model pattern
+	product := &EmbeddedProduct{
+		BaseModel: BaseModel{
+			PK:       "PRODUCT#prod_789",
+			SK:       "METADATA",
+			GSI1PK:   "TENANT#tenant_456",
+			GSI1SK:   "PRODUCT#prod_789",
+			GSI2PK:   "CATEGORY#electronics",
+			GSI2SK:   "PRODUCT#prod_789",
+			Type:     "product",
+			TenantID: "tenant_456",
+		},
+		ID:          "prod_789",
+		Name:        "Laptop",
+		Description: "High-performance laptop",
+		Price:       999.99,
+		Stock:       50,
+		CategoryID:  "electronics",
+	}
+
+	if err := db.Model(product).Create(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create an order linking customer and product
+	order := &EmbeddedOrder{
+		BaseModel: BaseModel{
+			PK:       "ORDER#ord_555",
+			SK:       "METADATA",
+			GSI1PK:   "CUSTOMER#cus_123",
+			GSI1SK:   fmt.Sprintf("ORDER#%d", time.Now().Unix()),
+			GSI2PK:   "TENANT#tenant_456",
+			GSI2SK:   fmt.Sprintf("ORDER#%d#ord_555", time.Now().Unix()),
+			Type:     "order",
+			TenantID: "tenant_456",
+		},
+		ID:         "ord_555",
+		CustomerID: "cus_123",
+		Total:      999.99,
+		Status:     "pending",
+		OrderedAt:  time.Now(),
+	}
+
+	if err := db.Model(order).Create(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Query all orders for a customer using GSI1
+	var orders []EmbeddedOrder
+	err = db.Model(&EmbeddedOrder{}).
+		Index("gsi1").
+		Where("GSI1PK", "=", "CUSTOMER#cus_123").
+		Where("GSI1SK", "BEGINS_WITH", "ORDER#").
+		OrderBy("GSI1SK", "DESC").
+		All(&orders)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Customer has %d orders\n", len(orders))
+
+	// Update customer email (which requires updating GSI2PK)
+	customer.Email = "johndoe@example.com"
+	customer.GSI2PK = "EMAIL#johndoe@example.com"
+
+	if err := db.Model(customer).Update("Email", "GSI2PK"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Customer email updated, UpdatedAt: %v\n", customer.UpdatedAt)
+}
+
+// Benefits of embedded structs:
+// 1. DRY (Don't Repeat Yourself) - Common fields defined once
+// 2. Consistent key structure across all entities
+// 3. Easy to maintain and refactor
+// 4. Type safety for common operations
+// 5. Perfect for single-table design patterns

--- a/pkg/marshal/marshaler.go
+++ b/pkg/marshal/marshaler.go
@@ -146,7 +146,7 @@ func (m *Marshaler) buildStructMarshaler(typ reflect.Type, metadata *model.Metad
 	}
 
 	for _, fieldMeta := range metadata.Fields {
-		field := typ.FieldByIndex([]int{fieldMeta.Index})
+		field := typ.FieldByIndex(fieldMeta.IndexPath)
 
 		// Count non-omitempty fields
 		if !fieldMeta.OmitEmpty || fieldMeta.IsCreatedAt || fieldMeta.IsUpdatedAt || fieldMeta.IsVersion {

--- a/pkg/marshal/safe_marshaler.go
+++ b/pkg/marshal/safe_marshaler.go
@@ -150,7 +150,7 @@ func (m *SafeMarshaler) buildSafeStructMarshaler(typ reflect.Type, metadata *mod
 		}
 
 		fm := safeFieldMarshaler{
-			fieldIndex:  []int{fieldMeta.Index},
+			fieldIndex:  fieldMeta.IndexPath,
 			dbName:      fieldMeta.DBName,
 			typ:         field.Type,
 			omitEmpty:   fieldMeta.OmitEmpty,

--- a/pkg/schema/transform.go
+++ b/pkg/schema/transform.go
@@ -155,7 +155,7 @@ func CreateModelTransform(transformFunc interface{}, sourceMetadata, targetMetad
 			}
 
 			// Get the struct field
-			structField := sourceModel.FieldByIndex([]int{field.Index})
+			structField := sourceModel.FieldByIndex(field.IndexPath)
 			if !structField.CanSet() {
 				continue
 			}

--- a/tests/integration/embedded_struct_test.go
+++ b/tests/integration/embedded_struct_test.go
@@ -1,0 +1,276 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// BaseModel represents common fields for single-table design
+type BaseModel struct {
+	// Primary composite keys
+	PK string `dynamorm:"pk"`
+	SK string `dynamorm:"sk"`
+
+	// Global Secondary Indexes
+	GSI1PK string `dynamorm:"index:gsi1,pk"`
+	GSI1SK string `dynamorm:"index:gsi1,sk"`
+	GSI2PK string `dynamorm:"index:gsi2,pk"`
+	GSI2SK string `dynamorm:"index:gsi2,sk"`
+
+	// Common metadata fields
+	Type      string    `dynamorm:"attr:type"`
+	AccountID string    `dynamorm:"attr:account_id"`
+	UpdatedAt time.Time `dynamorm:"updated_at"`
+	Version   int       `dynamorm:"version"`
+
+	// Soft delete support
+	Deleted   bool      `json:"deleted,omitempty" dynamorm:"attr:deleted"`
+	DeletedAt time.Time `json:"-" dynamorm:"attr:deleted_at"`
+}
+
+// EmbeddedCustomer model with embedded BaseModel
+type EmbeddedCustomer struct {
+	BaseModel // Embedded struct
+
+	// Customer-specific fields
+	ID      string `json:"id" dynamorm:"attr:id"`
+	Object  string `json:"object" dynamorm:"attr:object"`
+	Created int64  `json:"created" dynamorm:"attr:created"`
+	Email   string `json:"email" dynamorm:"attr:email"`
+	Name    string `json:"name" dynamorm:"attr:name"`
+}
+
+func (c *EmbeddedCustomer) TableName() string {
+	return "test-embedded-structs"
+}
+
+// EmbeddedProduct model also using embedded BaseModel
+type EmbeddedProduct struct {
+	BaseModel // Embedded struct
+
+	// Product-specific fields
+	ID          string  `json:"id" dynamorm:"attr:id"`
+	Name        string  `json:"name" dynamorm:"attr:name"`
+	Description string  `json:"description" dynamorm:"attr:description"`
+	Price       float64 `json:"price" dynamorm:"attr:price"`
+	Stock       int     `json:"stock" dynamorm:"attr:stock"`
+}
+
+func (p *EmbeddedProduct) TableName() string {
+	return "test-embedded-structs"
+}
+
+func TestEmbeddedStructSupport(t *testing.T) {
+	// Initialize test context with automatic cleanup
+	testCtx := InitTestDB(t)
+
+	// Create table with automatic cleanup
+	testCtx.CreateTableIfNotExists(t, &EmbeddedCustomer{})
+
+	t.Run("CreateWithEmbeddedStruct", func(t *testing.T) {
+		customer := &EmbeddedCustomer{
+			BaseModel: BaseModel{
+				PK:        "CUSTOMER#cus_test123",
+				SK:        "METADATA",
+				GSI1PK:    "ACCOUNT#acc_123",
+				GSI1SK:    "CUSTOMER#cus_test123",
+				GSI2PK:    "EMAIL#test@example.com",
+				GSI2SK:    "CUSTOMER#cus_test123",
+				Type:      "customer",
+				AccountID: "acc_123",
+			},
+			ID:      "cus_test123",
+			Object:  "customer",
+			Created: time.Now().Unix(),
+			Email:   "test@example.com",
+			Name:    "Test Customer",
+		}
+
+		// Create the customer
+		err := testCtx.DB.Model(customer).Create()
+		require.NoError(t, err)
+
+		// Verify UpdatedAt was set
+		assert.NotZero(t, customer.UpdatedAt)
+
+		// Read it back
+		var retrieved EmbeddedCustomer
+		err = testCtx.DB.Model(&EmbeddedCustomer{}).Where("PK", "=", "CUSTOMER#cus_test123").Where("SK", "=", "METADATA").First(&retrieved)
+		require.NoError(t, err)
+
+		// Verify all fields were saved correctly
+		assert.Equal(t, customer.PK, retrieved.PK)
+		assert.Equal(t, customer.SK, retrieved.SK)
+		assert.Equal(t, customer.GSI1PK, retrieved.GSI1PK)
+		assert.Equal(t, customer.GSI1SK, retrieved.GSI1SK)
+		assert.Equal(t, customer.Type, retrieved.Type)
+		assert.Equal(t, customer.AccountID, retrieved.AccountID)
+		assert.Equal(t, customer.ID, retrieved.ID)
+		assert.Equal(t, customer.Email, retrieved.Email)
+		assert.Equal(t, customer.Name, retrieved.Name)
+		assert.NotZero(t, retrieved.UpdatedAt)
+	})
+
+	t.Run("QueryByIndexWithEmbeddedStruct", func(t *testing.T) {
+		// Create multiple customers for the same account
+		for i := 1; i <= 3; i++ {
+			customer := &EmbeddedCustomer{
+				BaseModel: BaseModel{
+					PK:        fmt.Sprintf("CUSTOMER#cus_test%d", i),
+					SK:        "METADATA",
+					GSI1PK:    "ACCOUNT#acc_456",
+					GSI1SK:    fmt.Sprintf("CUSTOMER#cus_test%d", i),
+					GSI2PK:    fmt.Sprintf("EMAIL#test%d@example.com", i),
+					GSI2SK:    fmt.Sprintf("CUSTOMER#cus_test%d", i),
+					Type:      "customer",
+					AccountID: "acc_456",
+				},
+				ID:      fmt.Sprintf("cus_test%d", i),
+				Object:  "customer",
+				Created: time.Now().Unix(),
+				Email:   fmt.Sprintf("test%d@example.com", i),
+				Name:    fmt.Sprintf("Test Customer %d", i),
+			}
+
+			err := testCtx.DB.Model(customer).Create()
+			require.NoError(t, err)
+		}
+
+		// Query by GSI1
+		var customers []EmbeddedCustomer
+		err := testCtx.DB.Model(&EmbeddedCustomer{}).
+			Index("gsi1").
+			Where("GSI1PK", "=", "ACCOUNT#acc_456").
+			All(&customers)
+		require.NoError(t, err)
+
+		assert.Len(t, customers, 3)
+		for _, c := range customers {
+			assert.Equal(t, "ACCOUNT#acc_456", c.GSI1PK)
+			assert.Equal(t, "acc_456", c.AccountID)
+		}
+	})
+
+	t.Run("UpdateWithEmbeddedStruct", func(t *testing.T) {
+		customer := &EmbeddedCustomer{
+			BaseModel: BaseModel{
+				PK:        "CUSTOMER#cus_update",
+				SK:        "METADATA",
+				GSI1PK:    "ACCOUNT#acc_789",
+				GSI1SK:    "CUSTOMER#cus_update",
+				GSI2PK:    "EMAIL#original@example.com",
+				GSI2SK:    "CUSTOMER#cus_update",
+				Type:      "customer",
+				AccountID: "acc_789",
+			},
+			ID:    "cus_update",
+			Email: "original@example.com",
+			Name:  "Original Name",
+		}
+
+		// Create
+		err := testCtx.DB.Model(customer).Create()
+		require.NoError(t, err)
+
+		originalUpdatedAt := customer.UpdatedAt
+
+		// Wait a bit to ensure UpdatedAt changes
+		time.Sleep(100 * time.Millisecond)
+
+		// Update email
+		customer.Email = "updated@example.com"
+		customer.GSI2PK = "EMAIL#updated@example.com" // Update GSI key when email changes
+		err = testCtx.DB.Model(customer).Update("Email", "GSI2PK")
+		require.NoError(t, err)
+
+		// Read back the updated customer to get the new UpdatedAt
+		var updatedCustomer EmbeddedCustomer
+		err = testCtx.DB.Model(&EmbeddedCustomer{}).Where("PK", "=", "CUSTOMER#cus_update").Where("SK", "=", "METADATA").First(&updatedCustomer)
+		require.NoError(t, err)
+
+		// Verify UpdatedAt changed
+		assert.NotEqual(t, originalUpdatedAt, updatedCustomer.UpdatedAt)
+
+		// Read back to verify
+		var retrieved EmbeddedCustomer
+		err = testCtx.DB.Model(&EmbeddedCustomer{}).Where("PK", "=", "CUSTOMER#cus_update").Where("SK", "=", "METADATA").First(&retrieved)
+		require.NoError(t, err)
+
+		assert.Equal(t, "updated@example.com", retrieved.Email)
+		assert.Equal(t, "Original Name", retrieved.Name)
+	})
+
+	t.Run("MultipleEmbeddedStructTypes", func(t *testing.T) {
+		// Create a product using the same base model
+		product := &EmbeddedProduct{
+			BaseModel: BaseModel{
+				PK:        "PRODUCT#prod_123",
+				SK:        "METADATA",
+				GSI1PK:    "ACCOUNT#acc_123",
+				GSI1SK:    "PRODUCT#prod_123",
+				GSI2PK:    "CATEGORY#electronics",
+				GSI2SK:    "PRODUCT#prod_123",
+				Type:      "product",
+				AccountID: "acc_123",
+			},
+			ID:          "prod_123",
+			Name:        "Test Product",
+			Description: "A test product",
+			Price:       99.99,
+			Stock:       100,
+		}
+
+		err := testCtx.DB.Model(product).Create()
+		require.NoError(t, err)
+
+		// Verify it was created
+		var retrieved EmbeddedProduct
+		err = testCtx.DB.Model(&EmbeddedProduct{}).Where("PK", "=", "PRODUCT#prod_123").Where("SK", "=", "METADATA").First(&retrieved)
+		require.NoError(t, err)
+
+		assert.Equal(t, product.Name, retrieved.Name)
+		assert.Equal(t, product.Price, retrieved.Price)
+		assert.Equal(t, product.Stock, retrieved.Stock)
+		assert.NotZero(t, retrieved.UpdatedAt)
+	})
+
+	t.Run("SoftDeleteWithEmbeddedStruct", func(t *testing.T) {
+		customer := &EmbeddedCustomer{
+			BaseModel: BaseModel{
+				PK:        "CUSTOMER#cus_delete",
+				SK:        "METADATA",
+				GSI1PK:    "ACCOUNT#acc_999",
+				GSI1SK:    "CUSTOMER#cus_delete",
+				GSI2PK:    "EMAIL#delete@example.com",
+				GSI2SK:    "CUSTOMER#cus_delete",
+				Type:      "customer",
+				AccountID: "acc_999",
+			},
+			ID:    "cus_delete",
+			Email: "delete@example.com",
+			Name:  "To Be Deleted",
+		}
+
+		// Create
+		err := testCtx.DB.Model(customer).Create()
+		require.NoError(t, err)
+
+		// Soft delete
+		customer.Deleted = true
+		customer.DeletedAt = time.Now()
+		err = testCtx.DB.Model(customer).Update("Deleted", "DeletedAt")
+		require.NoError(t, err)
+
+		// Read back
+		var retrieved EmbeddedCustomer
+		err = testCtx.DB.Model(&EmbeddedCustomer{}).Where("PK", "=", "CUSTOMER#cus_delete").Where("SK", "=", "METADATA").First(&retrieved)
+		require.NoError(t, err)
+
+		assert.True(t, retrieved.Deleted)
+		assert.NotZero(t, retrieved.DeletedAt)
+	})
+}


### PR DESCRIPTION
## Summary

This PR introduces full support for embedded structs in DynamORM models, addressing a common limitation that prevented developers from using Go's composition features. This enhancement enables cleaner code organization, better reusability, and aligns DynamORM with Go best practices.

### Key Features
- ✅ Full support for anonymous (embedded) struct fields
- ✅ Recursive parsing of nested struct hierarchies
- ✅ Proper field access using reflection's FieldByIndex with paths
- ✅ Backward compatible - existing code continues to work unchanged

## Motivation

Previously, DynamORM would cause runtime panics when using embedded structs:
```go
type BaseModel struct {
    PK        string    `dynamorm:"pk"`
    SK        string    `dynamorm:"sk"`
    UpdatedAt time.Time `dynamorm:"updated_at"`
}

type Customer struct {
    BaseModel  // This would cause panic\!
    Name string
}
```

This limitation forced developers to duplicate common fields across all models, violating the DRY principle and making maintenance difficult, especially for single-table design patterns.

## Technical Implementation

### 1. Enhanced Field Metadata
- Updated `FieldMetadata` struct to store `IndexPath []int` instead of single `Index int`
- This allows proper access to fields in embedded structs using the full path

### 2. Recursive Field Parsing
- Created new `parseFields` function that recursively traverses embedded structs
- Properly handles anonymous struct fields while maintaining all metadata

### 3. Updated Field Access
- Modified all `FieldByIndex` calls throughout the codebase to use `IndexPath`
- Updated in: query operations, marshaling, unmarshaling, and updates

### Changes Made
- `pkg/model/registry.go`: Core parsing logic for embedded structs
- `dynamorm.go`: Updated field access operations
- `pkg/marshal/marshaler.go` & `safe_marshaler.go`: Marshaling support
- `pkg/schema/transform.go`: Schema transformation updates

## Example Usage

```go
// Define a base model with common fields
type BaseModel struct {
    PK        string    `dynamorm:"pk"`
    SK        string    `dynamorm:"sk"`
    GSI1PK    string    `dynamorm:"index:gsi1,pk"`
    GSI1SK    string    `dynamorm:"index:gsi1,sk"`
    UpdatedAt time.Time `dynamorm:"updated_at"`
    Version   int       `dynamorm:"version"`
}

// Use it in your models
type Customer struct {
    BaseModel  // All fields are inherited\!
    ID    string `dynamorm:"attr:id"`
    Email string `dynamorm:"attr:email"`
    Name  string `dynamorm:"attr:name"`
}

type Product struct {
    BaseModel  // Same base fields
    ID          string  `dynamorm:"attr:id"`
    Name        string  `dynamorm:"attr:name"`
    Price       float64 `dynamorm:"attr:price"`
}

// Works seamlessly
customer := &Customer{
    BaseModel: BaseModel{
        PK: "CUSTOMER#123",
        SK: "METADATA",
    },
    Name: "John Doe",
}
db.Model(customer).Create() // No more panic\!
```

## Testing

Added comprehensive integration tests in `tests/integration/embedded_struct_test.go`:
- ✅ Create operations with embedded structs
- ✅ Query operations including GSI queries
- ✅ Update operations with field tracking
- ✅ Multiple entity types sharing base model
- ✅ Soft delete patterns

All existing tests pass without modification, confirming backward compatibility.

## Benefits

1. **DRY Code**: Define common fields once, use everywhere
2. **Type Safety**: Embedded fields maintain their types and validation
3. **Single Table Design**: Perfect for DynamoDB single-table patterns
4. **Cleaner Code**: Better organization and maintainability
5. **Go Best Practices**: Aligns with idiomatic Go patterns

## Migration Guide

No migration required\! Existing code continues to work. To use embedded structs:

1. Define your base model with common fields
2. Embed it in your entity models using anonymous fields
3. Use as normal - DynamORM handles the rest

## Documentation

- Updated `CLAUDE.md` with embedded struct examples
- Added `examples/embedded_structs_example.go` demonstrating real-world usage
- Shows single-table design patterns with multiple entity types

## Checklist

- [x] Tests pass (`make test`)
- [x] Integration tests added
- [x] Documentation updated
- [x] Backward compatible
- [x] Example code provided

🤖 Generated with [Claude Code](https://claude.ai/code)